### PR TITLE
Update docs: HyprSpace migration, fix plugin counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ tags:
    - DO NOT: delete, rename, or modify trigger logic
 
 2. **Service restart sequences** (order matters)
-   - Always restart: yabai → skhd → sketchybar
+   - Always restart: HyprSpace → borders → sketchybar
    - Don't change service management procedures without testing
 
 3. **Stow directory structure**
@@ -29,8 +29,8 @@ tags:
 
 4. **Key system preferences**
    - Tmux prefix (Ctrl+A is intentional, not Ctrl+B)
-   - Yabai gap sizes (1px is intentional)
-   - Karabiner vs Kanata setup (user has chosen Kanata as PRIMARY)
+   - HyprSpace gap sizes (20px inner, 52px top for SketchyBar)
+   - Kanata is PRIMARY keyboard remapper (Karabiner unconfigured)
 
 ## 📂 Repository Structure
 
@@ -38,19 +38,19 @@ tags:
 
 ```
 dotfiles/
+├── aerospace/              # HyprSpace tiling WM: hyprspace.toml (dwindle layout)
+├── borders/                # JankyBorders: bordersrc (window borders)
 ├── zsh/                    # Shell: .zshrc, aliases, functions
-├── tmux/                   # Multiplexer: .tmux.conf + scripts/
-├── nvim/                   # Editor: 68 plugins (git subtree)
-├── yabai/                  # Window manager: yabairc
-├── skhd/                   # Hotkeys: skhdrc
-├── sketchybar/             # Menu bar: sketchybarrc + 69 plugins
-├── ghostty/                # Terminal: config
-├── starship/               # Prompt: 6 theme variants
+├── tmux/                   # Multiplexer: .tmux.conf + plugins
+├── nvim/                   # Editor: 42+ plugins (git subtree)
+├── sketchybar/             # Menu bar: sketchybarrc + 37 plugins
+├── ghostty/                # Terminal: config + 13 shaders
+├── starship/               # Prompt: 5 theme variants
 ├── kanata/                 # Keyboard: kanata.kbd (ACTIVE - PRIMARY)
 ├── karabiner/              # Keyboard alt: karabiner.json (inactive)
-├── sesh/                   # Session manager: sesh.toml
-├── tmuxinator/             # Complex layouts: YAML configs
-└── mcp/ + mcphub/          # Model Context Protocol
+├── sesh/                   # Session manager: sesh.toml + 25 scripts
+├── mcp/ + mcphub/          # Model Context Protocol
+└── claude/                 # Claude Code config + agents
 ```
 
 ### Documentation Files
@@ -74,33 +74,37 @@ dotfiles/
 
 ```bash
 # Prerequisites
-brew install yabai skhd sketchybar stow starship tmux
+brew install --cask BarutSRB/tap/hyprspace  # HyprSpace tiling WM
+brew tap FelixKratz/formulae && brew install borders  # JankyBorders
+brew install sketchybar stow starship tmux
 
 # Install all configs
 stow */
 
 # Start services
-brew services start yabai skhd sketchybar
+open -a HyprSpace  # App-based, not brew service
+brew services start sketchybar
 ```
 
 ### Service Management
 
 **Start**:
 ```bash
-brew services start yabai
-brew services start skhd
+open -a HyprSpace                          # Window manager (app)
+borders &                                   # Window borders
 brew services start sketchybar
 ```
 
 **Restart** (after config changes):
 ```bash
-brew services restart yabai
-brew services restart skhd
+killall HyprSpace && open -a HyprSpace     # Restart HyprSpace
+killall borders && borders &                # Restart borders
 brew services restart sketchybar
 ```
 
 **Reload** (without restart):
 ```bash
+hyprspace reload-config                     # Reload HyprSpace config
 sketchybar --reload
 tmux source-file ~/.tmux.conf
 exec zsh
@@ -110,17 +114,18 @@ exec zsh
 
 **Components WITH automated validation**:
 ```bash
-yabai --check-config              # Validate yabai config
-~/.config/sketchybar/test_sketchybar.sh   # Test SketchyBar plugins
-nvim --cmd "checkhealth"         # Neovim health check
+hyprspace reload-config                     # HyprSpace validates on reload
+~/.config/sketchybar/test_sketchybar.sh     # Test SketchyBar plugins
+nvim --cmd "checkhealth"                    # Neovim health check
 ```
 
 **Components WITHOUT automated validation**:
 ```bash
 # Manual checks required:
 sesh list                         # Check sesh (no script available)
-tail -f /usr/local/var/log/skhd/skhd.out.log  # SKHD errors
+killall borders && borders &      # Borders - restart to check
 tmux source-file ~/.tmux.conf     # Tmux syntax check
+# Check Console.app for HyprSpace errors
 ```
 
 **⚠️ Important**: `~/bin/validate_sesh.sh` was **REMOVED** in Oct 2025.
@@ -170,17 +175,19 @@ log stream --predicate 'process == "sketchybar"'
 ### Window Management Issues
 
 ```bash
-# Check service status
-brew services list | grep -E "(yabai|skhd)"
+# Check if HyprSpace is running
+pgrep -l HyprSpace
 
-# Validate yabai config
-yabai --check-config
+# Check if borders is running
+pgrep -l borders
 
-# Check SKHD logs
-tail -f /usr/local/var/log/skhd/skhd.out.log
+# Restart HyprSpace (validates config on startup)
+killall HyprSpace && open -a HyprSpace
 
-# Restart services
-brew services restart yabai skhd
+# Check Console.app for "HyprSpace" errors
+
+# Restart borders
+killall borders && borders &
 ```
 
 ### Session Management
@@ -198,19 +205,22 @@ tmux list-sessions
 
 ### Service Log Locations
 
-**Yabai**:
+**HyprSpace**:
 ```bash
-tail -f /usr/local/var/log/yabai/yabai.out.log
-```
-
-**SKHD**:
-```bash
-tail -f /usr/local/var/log/skhd/skhd.out.log
+# View in Console.app - filter for "HyprSpace"
+# Or use log stream:
+log show --predicate 'process == "HyprSpace"' --last 10m
 ```
 
 **SketchyBar**:
 ```bash
 log stream --predicate 'process == "sketchybar"'
+```
+
+**Kanata**:
+```bash
+sudo launchctl print system/com.example.kanata  # Check status
+log show --predicate 'process == "kanata"' --last 10m
 ```
 
 ## 🔄 Recent Changes
@@ -267,7 +277,7 @@ Referenced in:
 
 1. **Always validate configuration first**:
    ```bash
-   yabai --check-config  # For yabai changes
+   hyprspace reload-config  # For HyprSpace changes (validates on reload)
    tmux source-file ~/.tmux.conf  # For tmux changes
    ```
 
@@ -318,13 +328,13 @@ stow -D */ && stow */
 |-----------|------|---------|
 | Shell | `zsh/.zshrc` | Aliases, functions, keybinds |
 | Multiplexer | `tmux/.tmux.conf` | Ctrl+A prefix, theme |
-| Editor | `nvim/.config/nvim/init.lua` | 68 plugins, 45 configs |
-| Window Manager | `yabai/.config/yabai/yabairc` | BSP layout, 1px gaps |
-| Hotkeys | `skhd/.config/skhd/skhdrc` | Window management |
-| Menu Bar | `sketchybar/.config/sketchybar/sketchybarrc` | 69 plugins |
-| Terminal | `ghostty/.config/ghostty/config` | GPU-accelerated |
+| Editor | `nvim/.config/nvim/init.lua` | 42+ plugins (git subtree) |
+| Window Manager | `aerospace/.config/aerospace/hyprspace.toml` | Dwindle layout |
+| Window Borders | `borders/.config/borders/bordersrc` | JankyBorders |
+| Menu Bar | `sketchybar/.config/sketchybar/sketchybarrc` | 37 plugins |
+| Terminal | `ghostty/.config/ghostty/config` | GPU-accelerated + shaders |
 | Prompt | `starship/.config/starship/starship.toml` | Gruvbox Dark Neon |
-| Keyboard | `karabiner/.config/karabiner/karabiner.json` | Caps→Ctrl |
+| Keyboard | `kanata/.config/kanata/kanata.kbd` | Home row mods (PRIMARY) |
 
 ### Validation Scripts
 
@@ -387,4 +397,4 @@ stow -D */ && stow */
 
 **Remember**: When working with this repository, prioritize safety, testing, and thorough validation. The system is highly integrated, so changes in one area may affect others.
 
-*Last Updated: Oct 2025 - Post Sesh Script Migration*
+*Last Updated: Jan 2026 - HyprSpace + Dwindle Layout Migration*

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Feature-rich terminal session management:
 ### 🚀 **Starship** - Cross-Shell Prompt
 Highly customizable prompt with multiple themes:
 - **Active Theme**: Gruvbox Dark Neon
-- **Available Themes**: 6 different configurations
+- **Available Themes**: 5 different configurations
 - **Features**: Git integration, language detection, performance metrics
 - **Style**: Powerline-inspired with custom symbols
 
@@ -168,18 +168,18 @@ A powerful, modern Neovim setup based on kickstart.nvim with extensive customiza
 **Included via Git subtree** - works seamlessly on any system (macOS, Linux, Windows).
 
 **Quick Facts:**
-- **68 Plugins** across 45 configuration files
+- **42+ Plugins** across 39 configuration files
 - **100+ Keybindings** organized by function
 - **4 LSP Servers** configured (C/C++, Python, Rust, Lua)
 - **4 AI Integrations** (Claude, CodeCompanion, Copilot, SuperMaven)
-- **18 Treesitter Languages** for syntax highlighting
+- **40+ Treesitter Languages** for syntax highlighting
 
 **Key Features:**
 - AI-assisted development with Claude Code and CodeCompanion
 - Obsidian integration for knowledge management
-- Advanced git workflow (Neogit, Gitsigns, Fugitive)
+- Advanced git workflow (Neogit, Gitsigns)
 - DAP debugging with UI
-- Multiple file explorers (Mini.files, Oil, Neo-tree, Yazi)
+- Multiple file explorers (Mini.files, Oil, Yazi)
 - Tokyo Night theme with transparency
 
 **Complete Documentation:** See [nvim/README.md](nvim/README.md) for full details, keybindings, and setup instructions.
@@ -511,10 +511,10 @@ exec zsh                                  # Reload shell config
 ### Special Features
 - **HyprSpace**: Hyprland-style dwindle tiling (auto split direction)
 - **JankyBorders**: Visual window borders (green active, gray inactive)
-- **SketchyBar Plugins**: Custom status bar modules in `sketchybar/plugins/`
-- **Starship Themes**: 6 different prompt configurations
-- **Tmux Plugins**: Auto-installing plugin manager with 10+ plugins
-- **Neovim**: 68 plugins across 45 configuration files
+- **SketchyBar Plugins**: 37 custom status bar plugins in `sketchybar/plugins/`
+- **Starship Themes**: 5 different prompt configurations
+- **Tmux Plugins**: Auto-installing plugin manager with 11 plugins
+- **Neovim**: 42+ plugins across 39 configuration files (git subtree)
 
 ## 🤝 Contributing
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -107,10 +107,11 @@ pgrep -l borders                 # Check if running
 
 **Key Files**:
 - `sketchybar/.config/sketchybar/sketchybarrc` - Main configuration
-- `sketchybar/.config/sketchybar/plugins/` - 30+ plugin scripts
+- `sketchybar/.config/sketchybar/plugins/` - 37 plugin scripts
+- `sketchybar/.config/sketchybar/items/` - 29 item configurations
 - `sketchybar/.config/sketchybar/helper/` - C helper binary
 
-**Plugin Architecture**:
+**Plugin Architecture** (37 plugins total):
 ```
 plugins/
 ├── aerospace.sh          # HyprSpace workspace management (PRIMARY)
@@ -119,14 +120,23 @@ plugins/
 ├── space.sh             # Space display (click to switch)
 ├── brew.sh               # Package updates
 ├── calendar.sh           # Date/time display
-├── claude.sh             # Claude integration
-├── cpu.sh                # System monitoring
+├── cpu.sh                # System monitoring (via helper binary)
+├── memory.sh             # RAM usage
+├── disk.sh               # Disk usage
+├── battery.sh            # Battery status
 ├── front_app.sh          # Active application
 ├── git.sh                # Git repository status
 ├── github.sh             # GitHub notifications
+├── docker.sh             # Container monitoring
+├── dev_servers.sh        # Dev server port monitoring
 ├── temperature.sh        # CPU temperature (M4-aware, uses smctemp)
 ├── volume.sh             # Audio control
-└── ... (25+ more plugins)
+├── audio_output.sh       # Audio device indicator
+├── wifi.sh               # WiFi status
+├── network.sh            # Network speed
+├── ssh.sh                # SSH session indicator
+├── tmux.sh               # Tmux session indicator
+└── ... (15+ more plugins)
 ```
 
 **Temperature Monitoring (M4 Mac)**:
@@ -136,9 +146,9 @@ The temperature plugin uses `smctemp` to read heatsink temperature (TH0x sensor)
 - **Cache**: `/tmp/sketchybar_temp_cache`
 
 **Styling**:
-- **Position**: Top bar, 40px height
-- **Font**: MonaspiceRn Nerd Font
-- **Theme**: Blur effects with custom colors
+- **Position**: Top bar, 35px height
+- **Font**: MonaspiceKr Nerd Font
+- **Theme**: Green/orange color scheme with blur effects
 - **Interaction**: Click handlers for space switching
 
 **Testing & Validation**:
@@ -294,16 +304,16 @@ fv() { nvim "$(find . -type f -not -path '*/.*' | fzf)" }
 
 **Key Files**:
 - `starship/.config/starship/starship.toml` - Active configuration
-- `starship/.config/starship/starship-*.toml` - 6 theme variants
+- `starship/.config/starship/starship-*.toml` - 5 theme variants
 
-**Available Themes**:
+**Available Themes** (5 total):
 ```
 starship/
 ├── starship.toml                    # Default (Gruvbox Dark Neon)
 ├── starship-gruvbox-rainbow.toml    # Colorful variant
 ├── starship-jetpack.toml           # Minimal modern
 ├── starship-gruvbox-dark-neon.toml # High contrast
-└── ... (2 more variants)
+└── starship-tokyo-night.toml       # Tokyo Night variant
 ```
 
 **Theme Switching**:
@@ -330,7 +340,7 @@ export STARSHIP_CONFIG=~/.config/starship/starship-gruvbox-rainbow.toml
 **Key Files**:
 - `nvim/.config/nvim/init.lua` - Entry point
 - `nvim/.config/nvim/lua/keymaps.lua` - Core keybindings ([detailed guide](NEOVIM_KEYBINDS.md))
-- `nvim/.config/nvim/lua/custom/plugins/` - 30+ plugin configurations
+- `nvim/.config/nvim/lua/custom/plugins/` - 39 plugin configurations
 
 **Core Architecture**:
 ```

--- a/docs/KEYBINDS.md
+++ b/docs/KEYBINDS.md
@@ -17,8 +17,8 @@
 
 ## Window Management
 
-### Aerospace Window Operations (PRIMARY)
-*Source: `aerospace/.config/aerospace/aerospace.toml`*
+### HyprSpace Window Operations (PRIMARY)
+*Source: `aerospace/.config/aerospace/hyprspace.toml`*
 
 **Window Focus & Movement:**
 | Keybind | Action | Description |
@@ -354,7 +354,7 @@ Development:         ta (tmux), n (nvim), dps (docker ps)
 ```
 
 ### Integration Points
-- **Aerospace + Tmux**: Window and session management with integrated keybindings
+- **HyprSpace + Tmux**: Window and session management with integrated keybindings
 - **Sesh + Tmux**: Session management with enhanced workflow
 - **FZF + Multiple**: Fuzzy finding across file, session, git operations
 - **Eza + Navigation**: Enhanced listings in file operations

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -22,7 +22,8 @@ sesh list                                           # Sesh sessions (manual chec
 
 # Quick service status check
 brew services list | grep sketchybar
-pgrep -l AeroSpace  # Check Aerospace status
+pgrep -l HyprSpace  # Check HyprSpace status
+pgrep -l borders    # Check JankyBorders status
 ```
 
 ### 📋 Sesh Validation
@@ -90,30 +91,36 @@ cd ~/.config/sketchybar/helper && make clean && make
 **Start Services**:
 ```bash
 # Window management (Application, not Homebrew service)
-open -a AeroSpace
+open -a HyprSpace
+
+# Window borders
+borders &
 
 # Menu bar
 brew services start sketchybar
 
 # Check status
-pgrep -l AeroSpace
+pgrep -l HyprSpace
+pgrep -l borders
 brew services list | grep sketchybar
 ```
 
 **Restart Services** (after config changes):
 ```bash
 # Individual restarts
-killall AeroSpace && open -a AeroSpace  # Aerospace restarts and validates config
+killall HyprSpace && open -a HyprSpace  # HyprSpace restarts and validates config
+killall borders && borders &             # Restart window borders
 brew services restart sketchybar
 
 # Quick reload (within active session)
+hyprspace reload-config          # Reload HyprSpace config
 sketchybar --reload              # SketchyBar only
-# Note: Aerospace auto-validates config on startup
 ```
 
 **Stop Services**:
 ```bash
-killall AeroSpace                # Stop Aerospace
+killall HyprSpace                # Stop HyprSpace
+killall borders                  # Stop borders
 brew services stop sketchybar
 ```
 
@@ -132,10 +139,12 @@ tmux source-file ~/.tmux.conf
 exec zsh
 # or: source ~/.zshrc
 
-# Aerospace
+# HyprSpace
 # Auto-validates on startup - just restart to validate
-killall AeroSpace && open -a AeroSpace
-# Check Console.app for "AeroSpace" if errors occur
+killall HyprSpace && open -a HyprSpace
+# Or reload config without full restart:
+hyprspace reload-config
+# Check Console.app for "HyprSpace" if errors occur
 ```
 
 ---
@@ -146,21 +155,27 @@ killall AeroSpace && open -a AeroSpace
 
 **Window Management Issues**:
 ```bash
-# 1. Check if Aerospace is running
-pgrep -l AeroSpace
+# 1. Check if HyprSpace is running
+pgrep -l HyprSpace
 
-# 2. Check permissions
+# 2. Check if borders is running
+pgrep -l borders
+
+# 3. Check permissions
 # System Preferences > Security & Privacy > Accessibility
-# Ensure AeroSpace.app has permissions
+# Ensure HyprSpace.app has permissions
 
-# 3. Restart Aerospace (validates config on startup)
-killall AeroSpace && open -a AeroSpace
+# 4. Restart HyprSpace (validates config on startup)
+killall HyprSpace && open -a HyprSpace
 
-# 4. Check Aerospace logs (if issues occur)
-# Open Console.app and filter for "AeroSpace"
+# 5. Restart borders
+killall borders && borders &
 
-# 5. Verify configuration file exists
-ls -la ~/.config/aerospace/aerospace.toml
+# 6. Check HyprSpace logs (if issues occur)
+# Open Console.app and filter for "HyprSpace"
+
+# 7. Verify configuration file exists
+ls -la ~/.config/aerospace/hyprspace.toml
 ```
 
 **SketchyBar Issues**:
@@ -352,17 +367,22 @@ stow --adopt component_name  # Adopt existing files
 **Solutions**:
 1. **Check Accessibility Permissions**:
    - System Preferences > Security & Privacy > Accessibility
-   - Add and enable `AeroSpace.app`
+   - Add and enable `HyprSpace.app`
 
-2. **Restart Aerospace**:
+2. **Restart HyprSpace**:
    ```bash
-   killall AeroSpace && open -a AeroSpace
+   killall HyprSpace && open -a HyprSpace
    ```
 
-3. **Check Configuration**:
-   - Aerospace validates config on startup
-   - Check Console.app for "AeroSpace" errors if issues occur
-   - Verify config file: `~/.config/aerospace/aerospace.toml`
+3. **Restart JankyBorders** (if borders not showing):
+   ```bash
+   killall borders && borders &
+   ```
+
+4. **Check Configuration**:
+   - HyprSpace validates config on startup
+   - Check Console.app for "HyprSpace" errors if issues occur
+   - Verify config file: `~/.config/aerospace/hyprspace.toml`
 
 ### ❌ SketchyBar Not Displaying
 
@@ -469,7 +489,8 @@ stow --adopt component_name  # Adopt existing files
 **If everything breaks**:
 ```bash
 # 1. Stop all services
-killall AeroSpace
+killall HyprSpace
+killall borders
 brew services stop sketchybar
 
 # 2. Backup current config
@@ -481,7 +502,8 @@ stow -D */  # Remove all stow links
 stow */     # Re-create all links
 
 # 4. Restart services
-open -a AeroSpace
+open -a HyprSpace
+borders &
 brew services start sketchybar
 
 # 5. Restart shell

--- a/docs/WORKFLOW_GUIDES.md
+++ b/docs/WORKFLOW_GUIDES.md
@@ -143,15 +143,15 @@ ghl                        # List GitHub repos (if using GitHub CLI)
 
 ### Seamless Window & Pane Navigation
 
-**Goal**: Unified navigation across Aerospace windows and Tmux panes
+**Goal**: Unified navigation across HyprSpace windows and Tmux panes
 
 ```bash
-# Aerospace Window Management (system-wide - PRIMARY)
+# HyprSpace Window Management (system-wide - PRIMARY with Dwindle layout)
 Shift+Ctrl+h/j/k/l         # Focus windows
 Shift+Ctrl+Alt+h/j/k/l     # Move windows
 Ctrl+Alt+Cmd+j/k           # Resize windows (smart, context-aware)
-Cmd+Ctrl+j/k/l             # Switch workspaces 1-3
-Ctrl+Shift+4-9             # Switch workspaces 4-9
+Cmd+j/k/l                  # Switch workspaces 1-3 (homerow)
+Ctrl+Shift+1-9             # Switch workspaces 1-9
 
 # Tmux Pane Management (within terminal)
 C-a h/j/k/l                # Focus panes
@@ -168,7 +168,8 @@ C-a v                      # Horizontal split
 ### Layout Management
 
 ```bash
-# Aerospace Layouts (PRIMARY)
+# HyprSpace Layouts (PRIMARY - Dwindle Layout)
+# Note: Dwindle auto-splits based on window aspect ratio
 Shift+Ctrl+e               # Toggle float/tile
 Shift+Ctrl+v               # Toggle horizontal/vertical orientation
 Shift+Ctrl+t               # Tiles layout
@@ -381,7 +382,7 @@ gp                         # Push changes
 | Session Management | Sesh + Tmux + FZF | Shared session names, FZF selection |
 | File Navigation | Eza + Yazi + Telescope | Consistent preview, similar interfaces |
 | Git Operations | Zsh aliases + Neogit | Quick terminal ops, detailed GUI ops |
-| Window Management | Aerospace + Tmux + Neovim | Unified navigation keybinds |
+| Window Management | HyprSpace + JankyBorders + Tmux + Neovim | Unified navigation keybinds, dwindle layout |
 | Search | FZF + Telescope + ripgrep | Consistent fuzzy finding paradigm |
 | Note-Taking | Obsidian + Telescope | Cross-search capabilities |
 


### PR DESCRIPTION
- Replace all yabai/skhd references with HyprSpace/JankyBorders in AGENTS.md
- Update service management commands for HyprSpace (app) vs brew service
- Fix SketchyBar plugin count: 37 plugins, 29 items (not "30+" or "69")
- Fix Starship themes: 5 available (not 6)
- Fix Neovim plugins: 42+ across 39 configs (not 68)
- Update Tmux plugins: 11 total
- Add JankyBorders references throughout documentation
- Update validation commands for HyprSpace (reload-config, Console.app)
- Correct hyprspace.toml file references
- Update last-updated date to Jan 2026