### PR TITLE
feat: add Ghostty Shift+Enter newline binding

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -41,6 +41,8 @@ macos-secure-input-indication = false
 keybind = ctrl+l=unbind
 keybind = cmd+shift+p=unbind
 keybind = global:ctrl+enter=toggle_quick_terminal
+# Send Esc+Enter so Hermes CLI treats Shift+Enter as an inserted newline.
+keybind = shift+enter=text:\x1b\r
 keybind = "cmd+shift+s=toggle_secure_input"
 
 # Ghostty Custom shaders


### PR DESCRIPTION
## Summary
- Add a Ghostty Shift+Enter keybind that sends Esc+Enter (\x1b\r)
- Lets Hermes CLI insert a newline with Shift+Enter, matching the already-working Alt+Enter behavior
- Add a short comment explaining why the escape sequence exists

## Validation
- Confirmed manually in Hermes CLI that Shift+Enter inserts a newline
- Ran `ghostty +show-config` and verified the keybind is loaded
- Independently reviewed the diff: no security concerns or logic errors