### PR TITLE
Install Brewfile in bootstrap + document manual macOS steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,20 +299,21 @@ brew install uv node python kubectl kubectx kubens docker switchaudio-osx kanata
    cd ~/dotfiles
    ```
 
-2. **Install configurations using Stow** (run from the platform subdirectory):
+2. **Run the bootstrap script** (recommended — installs Homebrew, all Brewfile
+   apps/casks/fonts, stows every config, sets up TPM and the Kanata daemon):
    ```bash
-   # Install GNU Stow if not already installed
-   brew install stow
-
-   # macOS: stow from mac/
-   cd ~/dotfiles/mac
-   stow zsh tmux ghostty aerospace borders sketchybar kanata karabiner sesh starship hammerspoon
-
-   # The easy path: run the bootstrap script instead
+   # macOS
    ~/dotfiles/mac/bootstrap.sh
+
+   # Linux (Omarchy)
+   ~/dotfiles/linux/bootstrap.sh
    ```
 
-   On Linux (Omarchy), stow from `linux/` instead (or run `~/dotfiles/linux/bootstrap.sh`).
+   Or stow manually from the platform subdirectory if you only want the symlinks:
+   ```bash
+   cd ~/dotfiles/mac
+   stow zsh tmux ghostty aerospace borders sketchybar kanata karabiner sesh starship hammerspoon
+   ```
 
 3. **Start services:**
    ```bash
@@ -332,10 +333,27 @@ brew install uv node python kubectl kubectx kubens docker switchaudio-osx kanata
    nvim  # Wait for plugins to download (~30-60 seconds)
    ```
 
-4. **Configure permissions:**
-   - Grant accessibility permissions to Aerospace in System Preferences
-   - Allow Karabiner-Elements to modify keyboard input
-   - Configure Ghostty as default terminal
+4. **Manual macOS steps** (cannot be scripted — Apple security / TCC):
+
+   These are the pieces `bootstrap.sh` *can't* do for you on a fresh machine:
+
+   - **Karabiner DriverKit VirtualHIDDevice** — Kanata's keyboard remapping
+     **will not work without it**, and it is *not* a Homebrew cask. Install the
+     pinned driver (Kanata 1.11 is incompatible with DriverKit v7 — use **6.6.0**):
+     ```bash
+     # Download + install the v6.6.0 .pkg from the Karabiner releases:
+     #   https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases
+     # then activate it:
+     sudo /Applications/.Karabiner-VirtualHIDDevice-Manager.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Manager activate
+     ```
+   - **Input Monitoring** — grant it to `kanata` in System Settings → Privacy &
+     Security → Input Monitoring (the remaps stay dead until you do).
+   - **Accessibility** — grant it to **AeroSpace** and **Hammerspoon** in
+     System Settings → Privacy & Security → Accessibility.
+   - **Ghostty** — set as the default terminal if desired.
+
+   > See the `provision-mac-twin` skill for the full fresh-Mac walkthrough,
+   > including the Homebrew 6.x / Kanata / TCC gotchas.
 
 ## 📦 Neovim Configuration
 

--- a/mac/bootstrap.sh
+++ b/mac/bootstrap.sh
@@ -17,14 +17,23 @@ if ! command -v brew &>/dev/null; then
 fi
 echo "✓ Homebrew available"
 
-# 2. Check stow
+# 2. Install everything from the Brewfile (apps, casks, fonts, CLIs incl. stow)
+BREWFILE="$DOTFILES_DIR/macos/Brewfile"
+if [[ -f "$BREWFILE" ]]; then
+  echo "Installing packages from Brewfile (this can take a while on a fresh machine)..."
+  # Don't abort the whole bootstrap if one cask fails — surface it and continue.
+  brew bundle --file="$BREWFILE" || echo "⚠ Some Brewfile entries failed — review the output above"
+  echo "✓ Brewfile processed"
+fi
+
+# 3. Check stow (Brewfile installs it, but keep a fallback)
 if ! command -v stow &>/dev/null; then
   echo "Installing stow..."
   brew install stow
 fi
 echo "✓ GNU Stow available"
 
-# 3. Back up conflicting files and stow
+# 4. Back up conflicting files and stow
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 BACKUP_DIR="$HOME/dotfiles-backup-$TIMESTAMP"
 CONFLICTS=false
@@ -56,7 +65,7 @@ for pkg in "${PACKAGES[@]}"; do
   echo "✓ Stowed $pkg"
 done
 
-# 4. Clone TPM for tmux if missing
+# 5. Clone TPM for tmux if missing
 if [[ ! -d ~/.tmux/plugins/tpm ]]; then
   echo "Installing Tmux Plugin Manager..."
   mkdir -p ~/.tmux/plugins
@@ -66,7 +75,7 @@ else
   echo "✓ TPM already installed"
 fi
 
-# 5. Kanata LaunchDaemon
+# 6. Kanata LaunchDaemon
 PLIST_SRC="$DOTFILES_DIR/kanata/.config/kanata/com.example.kanata.plist"
 PLIST_DST="/Library/LaunchDaemons/com.example.kanata.plist"
 if [[ -f "$PLIST_SRC" && ! -f "$PLIST_DST" ]]; then


### PR DESCRIPTION
## Summary

Closes the fresh-M1 provisioning gap found after #8: `bootstrap.sh` installed Homebrew + stow but **nothing ran `brew bundle`**, so a clean Mac got symlinks and none of the apps — and kanata had no driver.

## Changes

- **`mac/bootstrap.sh`**: new step 2 runs `brew bundle --file=macos/Brewfile` right after Homebrew, installing all apps/casks/fonts/CLIs (incl. stow). Single-cask failures are tolerated (`|| echo`) so one bad entry doesn't abort the whole run under `set -e`. Steps renumbered 1–6.
- **`README.md`**: bootstrap is now the recommended path; replaced the thin/stale "Configure permissions" note (which referenced unused Karabiner-Elements) with an accurate **Manual macOS steps** section — the inherently-unscriptable TCC bits:
  - Karabiner DriverKit **v6.6.0** pinned `.pkg` install (kanata's required driver; not a brew cask; v7 breaks kanata 1.11)
  - Input Monitoring → kanata
  - Accessibility → AeroSpace + Hammerspoon
  - pointer to the `provision-mac-twin` skill

## Notes

- The Karabiner driver stays manual on purpose — it's a pinned `.pkg`, not brew-installable, and TCC grants can't be scripted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)