### PR TITLE
Fix sc(): remove exec </dev/tty that broke sesh/tmux attach

### DIFF
--- a/mac/zsh/.zshrc
+++ b/mac/zsh/.zshrc
@@ -260,11 +260,13 @@ alias vault="cd ~/vault && nvim index.md"
 alias sl='sesh list -t -c -d'                      # List sessions (compact, deduplicated)
 
 sc() {
-    exec </dev/tty
-    exec <&0
+    # NOTE: do NOT add `exec </dev/tty` here — it poisons the shell's stdin and
+    # makes `tmux attach` fail with "can't use /dev/tty" (and breaks bare tmux
+    # afterward). fzf opens /dev/tty itself, so it isn't needed.
     local session="${1:-$(sesh list | fzf --height 40% --reverse --border)}"
     [[ -z "$session" ]] && return
-    TMUX= sesh connect "$session"
+    # No `TMUX=` prefix: let sesh switch-client when inside tmux, attach when out.
+    sesh connect "$session"
 }
 
 # Management aliases


### PR DESCRIPTION
## Problem
`sc` (sesh connect wrapper) always failed with **"Failed to attach to tmux session: exit status 1"** in a normal terminal, outside tmux. Bare `tmux` would then also fail with `open terminal failed: can't use /dev/tty`.

## Root cause
`sc()` ran `exec </dev/tty; exec <&0` before `sesh connect`. That redirect breaks `tmux attach` ("can't use /dev/tty"), and since `exec` mutates the interactive shell's fd 0, it poisoned the shell so subsequent bare `tmux` also failed.

## Proof
In a real Ghostty tty (TERM=xterm-ghostty, outside tmux):
- `sesh connect dotfiles` → exit 124 (connected, works)
- `exec </dev/tty; exec <&0; sesh connect dotfiles` → exit 1 (the reported error)
- after removing the redirects, `sc dotfiles` attaches a client (`ttys005 → dotfiles`) ✓

## Fix
Drop the `exec </dev/tty` / `exec <&0` lines (fzf opens /dev/tty itself, so they were never needed) and the `TMUX=` prefix (so sesh `switch-client`s when inside tmux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)