### PR TITLE
Fix Linux sc(): same exec </dev/tty / TMUX= fix as #10

### DIFF
--- a/linux/zsh/.zshrc
+++ b/linux/zsh/.zshrc
@@ -38,11 +38,12 @@ alias conf="cd ~/.config && nvim"
 alias sl='sesh list -t -c -d'
 
 sc() {
-    exec </dev/tty
-    exec <&1
+    # NOTE: do NOT add `exec </dev/tty` here — it poisons the shell's stdin and
+    # makes `tmux attach` fail with "can't use /dev/tty". fzf opens /dev/tty itself.
     local session="${1:-$(sesh list | fzf --height 40% --reverse --border)}"
     [[ -z "$session" ]] && return
-    TMUX= sesh connect "$session"
+    # No `TMUX=` prefix: let sesh switch-client when inside tmux, attach when out.
+    sesh connect "$session"
 }
 
 alias tkas='tmux kill-server'


### PR DESCRIPTION
Mirrors #10 on the Linux side — `linux/zsh/.zshrc` had the identical `sc()` bug (`exec </dev/tty` breaks tmux attach; `TMUX=` force-attaches inside tmux). Removed both so `sesh connect` works on Omarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)